### PR TITLE
HYP-98: including the timeline component into the certificate page.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.11",
             "license": "Apache-2.0",
             "dependencies": {
-                "@digicatapult/ui-component-library": "^0.14.6",
+                "@digicatapult/ui-component-library": "^0.16.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-router-dom": "^6.21.3",
@@ -1835,9 +1835,9 @@
             }
         },
         "node_modules/@digicatapult/ui-component-library": {
-            "version": "0.14.7",
-            "resolved": "https://registry.npmjs.org/@digicatapult/ui-component-library/-/ui-component-library-0.14.7.tgz",
-            "integrity": "sha512-HImN16khW7Vcnh338H3rLx1lwJHMRRI3x8Q10wS2mKSPV4V3muy7SPFfWLMGP4m1+u89uS2z4bZUPcK6fbfHfA==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@digicatapult/ui-component-library/-/ui-component-library-0.16.0.tgz",
+            "integrity": "sha512-c3VcVLUMohElVWnHMyqig3YMwVAK9gQxCPkGh9PN57+KVlNHgu++zsXIbIBHsMKJ9KUqpC6P/5i8Pmc7jDHlCw==",
             "dependencies": {
                 "geojson": "^0.5.0",
                 "jsqr": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/dscp-hyproof-client",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/dscp-hyproof-client",
-            "version": "0.0.11",
+            "version": "0.0.12",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/dscp-hyproof-client",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/dscp-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "webpack-dev-server": "^4.15.1"
     },
     "dependencies": {
-        "@digicatapult/ui-component-library": "^0.14.6",
+        "@digicatapult/ui-component-library": "^0.16.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.3",

--- a/src/pages/Certificates.js
+++ b/src/pages/Certificates.js
@@ -4,6 +4,29 @@ import Nav from './components/Nav'
 import Header from './components/Header'
 import CertificateForm from './components/CertificateForm'
 
+const timelineProps = {
+  name: 'UK-HYPROOF-0001',
+  disclaimer:
+    'Your certification status is dynamic and may change  over time. Always refer to this page for the most up-to-date status.',
+  items: [
+    {
+      title: 'Initiation',
+      message:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.',
+      checked: true,
+      status: 'in progress',
+    },
+    {
+      title: 'Carbon Embodiment',
+      status: 'pending',
+    },
+    {
+      title: 'Issuance',
+      status: 'pending',
+    },
+  ],
+}
+
 export default function Certificates() {
   const userName = 'Heidi Heidi'
   const companyName = "Heidi's Hydroelectric Hydrogen"
@@ -11,7 +34,7 @@ export default function Certificates() {
     <>
       <Nav />
       <Header userFullName={userName} companyName={companyName} />
-      <CertificateForm />
+      <CertificateForm variant="hyproof" {...timelineProps} />
     </>
   )
 }

--- a/src/pages/components/CertificateForm.js
+++ b/src/pages/components/CertificateForm.js
@@ -4,23 +4,11 @@ import styled from 'styled-components'
 import { Grid, Timeline } from '@digicatapult/ui-component-library'
 
 export default function CertificateForm(props) {
-  const [items, setItems] = React.useState(props.items || undefined)
-
-  React.useEffect(() => {
-    // This is for api to retrieve status of a certificate
-    // once updated delete [timelineItems] variable
-    if (!items) {
-      fetch('localhost:3001/some-link/{id}')
-        .then((res) => res.json())
-        .then((data) => setItems(data))
-    }
-  }, [items])
-
   return (
     <Form>
       <TimelineWrapper area="timeline">
         <Timeline {...props}>
-          {items.map(({ message, ...rest }) => (
+          {props.items.map(({ message, ...rest }) => (
             <Timeline.Item key={rest.title} {...props} {...rest}>
               {message && <p>{message}</p>}
             </Timeline.Item>

--- a/src/pages/components/CertificateForm.js
+++ b/src/pages/components/CertificateForm.js
@@ -1,12 +1,33 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Grid } from '@digicatapult/ui-component-library'
+import { Grid, Timeline } from '@digicatapult/ui-component-library'
 
-export default function CertificateForm() {
+export default function CertificateForm(props) {
+  const [items, setItems] = React.useState(props.items || undefined)
+
+  React.useEffect(() => {
+    // This is for api to retrieve status of a certificate
+    // once updated delete [timelineItems] variable
+    if (!items) {
+      fetch('localhost:3001/some-link/{id}')
+        .then((res) => res.json())
+        .then((data) => setItems(data))
+    }
+  }, [items])
+
   return (
     <Form>
-      <Timeline area="timeline">timeline</Timeline>
+      <TimelineWrapper area="timeline">
+        <Timeline {...props}>
+          {items.map(({ message, ...rest }) => (
+            <Timeline.Item key={rest.title} {...props} {...rest}>
+              {message && <p>{message}</p>}
+            </Timeline.Item>
+          ))}
+        </Timeline>
+        <TimelineDisclaimer>{props.disclaimer}</TimelineDisclaimer>
+      </TimelineWrapper>
       <Grid.Panel area="main">
         <h1>Certificate Form</h1>
       </Grid.Panel>
@@ -21,14 +42,20 @@ const Form = styled.form`
   grid-area: 1 / 1 / -1 / -1;
 `
 
-const Timeline = styled(Grid.Panel)`
-  display: grid;
-  align-items: center;
-  justify-items: center;
-  min-width: 400px;
-  max-height: 600px;
-  color: white;
+const TimelineWrapper = styled(Grid.Panel)`
+  max-width: 400px;
+  max-height: 100%;
+  padding: 20px 0px;
+  overflow: hidden;
   background: #0c3b38;
+`
+
+const TimelineDisclaimer = styled('div')`
+  padding: 50px 20px;
+  color: #33e58c;
+  opacity: 0.5;
+  font-size: 12px;
+  line-height: 20px; /* 166.667% */
 `
 
 const Sidebar = styled(Grid.Panel)`


### PR DESCRIPTION
# What

As part of a [HYP-1](https://digicatapult.atlassian.net/browse/HYP-1) including timeline component that was created separately. Please find some screenshots and more on the component itself can be found in [ui-lib](https://github.com/digicatapult/ui-component-library)

## Screenshots

<img width="419" alt="Screenshot 2024-01-24 at 1 05 23 pm" src="https://github.com/digicatapult/dscp-hyproof-client/assets/11794402/eeff01cc-627e-4daa-b9fd-17a1cc27b05b">
<img width="811" alt="Screenshot 2024-01-24 at 1 05 18 pm" src="https://github.com/digicatapult/dscp-hyproof-client/assets/11794402/511a237c-9560-4cf2-8d00-e64a5609afb5">
