### PR TITLE
HYP-110: wrapper for displaying borders.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/dscp-hyproof-client",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/dscp-hyproof-client",
-            "version": "0.0.14",
+            "version": "0.0.15",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/dscp-hyproof-client",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/dscp-hyproof-client",
     "main": "src/index.js",

--- a/src/App.js
+++ b/src/App.js
@@ -4,15 +4,38 @@ import { RouterProvider } from 'react-router-dom'
 
 import { router } from './utils/Router'
 import { Grid } from '@digicatapult/ui-component-library'
+import { Context } from './utils/Context'
+
+const colorMap = {
+  emma: '#AAED93',
+  heidi: '#FDB6D4',
+  reginald: '#FCF281',
+}
 
 const FullScreenGrid = styled(Grid)`
   height: 100lvh;
   width: 100lvw;
+  overflow: hidden;
+  border: ${({ showSelector, color }) =>
+    showSelector ? '20px solid ' + color : 'none'};
 `
 
 export default function App() {
+  const { update, current, showSelector } = React.useContext(Context)
+  const color = colorMap[current] || 'none'
+
+  const handlePersonaSwitch = (persona) => {
+    if (current != persona) {
+      return update({ current: persona })
+    }
+  }
+
+  handlePersonaSwitch('emma')
+
   return (
     <FullScreenGrid
+      color={color}
+      showSelector={showSelector}
       areas={[
         ['home', 'nav', 'nav'],
         ['header', 'header', 'sidebar'],

--- a/src/utils/Context.js
+++ b/src/utils/Context.js
@@ -1,35 +1,33 @@
 import React from 'react'
 
-export const initState = {
-  current: 'heidi',
-  emma: {
-    color: '#AAED93',
-  },
-  heidi: {
-    name: 'Heidi Heidi',
-    company: "Heidi's Hydroelectric Hydrogen",
-    color: '#FDB6D4',
-  },
-  reginald: {
-    color: '#FCF281',
-  },
-}
-
-export const Context = React.createContext({
-  current: 'heidi',
-  emma: {},
-  heidi: {},
-  reginald: {},
-  update: () => {},
-})
+export const Context = React.createContext({})
 
 // this is a provider for initial and state updates
 export const ContextProvider = ({ children }) => {
   const [state, setState] = React.useState({
-    ...initState,
-    update: (key, val) => {
-      const update = { [key]: { ...state[key], ...val } }
-      setState({ ...state, [key]: update })
+    current: 'heidi',
+    showSelector: true,
+    emma: {
+      name: 'Emma Emma',
+    },
+    heidi: {
+      name: 'Heidi Heidi',
+      company: "Heidi's Hydroelectric Hydrogen",
+    },
+    reginald: {
+      name: 'Reginald Reginald',
+    },
+    update: (val, key) => {
+      if (!val) return state
+      if (!key) return setState({ ...state, ...val })
+
+      setState({
+        ...state,
+        [key]: {
+          ...state[key],
+          ...val,
+        },
+      })
     },
   })
 


### PR DESCRIPTION
# What

A wrapper around FullScreen component which we will need for selector. This is the preparation for the selector. Updated context a little and added a color map (currently within App.js until more suitable location found).

<img width="1726" alt="Screenshot 2024-01-30 at 6 05 49 am" src="https://github.com/digicatapult/dscp-hyproof-client/assets/11794402/639d4355-3fec-4408-83c6-2c77b82bbb02">
<img width="730" alt="Screenshot 2024-01-30 at 6 08 07 am" src="https://github.com/digicatapult/dscp-hyproof-client/assets/11794402/189b5960-4c6d-4db5-a8ef-e82767ae80f1">
<img width="221" alt="Screenshot 2024-01-30 at 6 08 02 am" src="https://github.com/digicatapult/dscp-hyproof-client/assets/11794402/3e76b12a-8b5f-4c60-9fd8-fc946ed73f79">
<img width="195" alt="Screenshot 2024-01-30 at 6 07 58 am" src="https://github.com/digicatapult/dscp-hyproof-client/assets/11794402/41055caf-6ace-4113-b010-9f78f1ae3794">
